### PR TITLE
feature(backend): Index `OriginEvent` event in `RelayPool`

### DIFF
--- a/backend/src/handlers/RelayPool/OriginAdded.ts
+++ b/backend/src/handlers/RelayPool/OriginAdded.ts
@@ -1,0 +1,23 @@
+import { Context, Event } from 'ponder:registry'
+import { poolOrigin } from 'ponder:schema'
+
+export default async function ({
+  event,
+  context,
+}: {
+  event: Event<'RelayPool:OriginAdded'>
+  context: Context<'RelayPool:OriginAdded'>
+}) {
+  const { origin } = event.args
+  const poolAddress = event.log.address
+
+  // Insert the pool origin
+  await context.db.insert(poolOrigin).values({
+    chainId: context.network.chainId,
+    pool: poolAddress as `0x${string}`,
+    proxyBridge: origin.proxyBridge as `0x${string}`,
+    originChainId: origin.chainId,
+    originBridge: origin.bridge as `0x${string}`,
+    maxDebt: origin.maxDebt,
+  })
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -22,24 +22,61 @@ import Withdraw from './handlers/RelayPool/Withdraw'
 import PoolDeployed from './handlers/RelayPoolFactory/PoolDeployed'
 import BridgeDeployed from './handlers/RelayBridgeFactory/BridgeDeployed'
 import BridgeInitiated from './handlers/RelayBridge/BridgeInitiated'
+import OriginAdded from './handlers/RelayPool/OriginAdded'
 
 // ============= RelayPool Events =============
 
 /**
  * Handles deposits into the RelayPool
- *
- * Efficient patterns used:
- * - Composite ID generation for unique records
+ * Updates:
+ * - Pool total assets and shares
+ * - User balance records
+ * - Yield pool state
+ * - Creates pool action record
  */
 ponder.on('RelayPool:Deposit', Deposit)
 
 /**
  * Handles withdrawals from the RelayPool
+ * Updates:
+ * - Pool total assets and shares
+ * - User balance records
+ * - Yield pool state
+ * - Creates pool action record
  */
 ponder.on('RelayPool:Withdraw', Withdraw)
 
+/**
+ * Handles the deployment of a new RelayPool
+ * Creates:
+ * - New relay pool record
+ * - Associated yield pool record
+ * - Initial origin configurations
+ */
 ponder.on('RelayPoolFactory:PoolDeployed', PoolDeployed)
 
+/**
+ * Handles the deployment of a new RelayBridge
+ * Creates:
+ * - New bridge contract record
+ * - Initializes transfer nonce tracking
+ */
 ponder.on('RelayBridgeFactory:BridgeDeployed', BridgeDeployed)
 
+/**
+ * Handles the initiation of a RelayBridge transaction
+ * Creates:
+ * - Bridge transaction record
+ * - Links origin and destination pools
+ * - Tracks cross-chain message status
+ */
 ponder.on('RelayBridge:BridgeInitiated', BridgeInitiated)
+
+/**
+ * Handles the addition of a new origin to a RelayPool
+ * Creates:
+ * - New pool origin record
+ * - Links bridge and proxy bridge contracts
+ * - Sets initial debt limits
+ */
+ponder.on('RelayPool:OriginAdded', OriginAdded)


### PR DESCRIPTION
This PR introduces indexing support for the `OriginAdded` event in `RelayPool`, allowing tracking of new origins added post-deployment.