### PR TITLE
chore(smart-contracts): remove `semver` lib

### DIFF
--- a/smart-contracts/package.json
+++ b/smart-contracts/package.json
@@ -55,7 +55,6 @@
     "pinst": "3.0.0",
     "prettier": "3.4.2",
     "prettier-plugin-solidity": "1.4.2",
-    "semver": "7.6.3",
     "solhint": "5.0.5",
     "solidity-coverage": "0.8.14",
     "ts-node": "10.9.2",

--- a/smart-contracts/tasks/utils/exportAbis.ts
+++ b/smart-contracts/tasks/utils/exportAbis.ts
@@ -1,5 +1,4 @@
 import fs from 'fs-extra'
-import semver from 'semver'
 import path from 'path'
 
 import { task } from 'hardhat/config'
@@ -13,12 +12,8 @@ const ignored = [
   'contracts/utils',
 ]
 
-task('export:abis', 'Export ABIs to a node package')
-  .addOptionalParam('previousVersion', 'version of the package to publish')
-  .setAction(async ({ previousVersion }, { artifacts }) => {
-    const version = semver.inc(previousVersion, 'patch')
-    console.log(`Releasing version : ${version}`)
-
+task('export:abis', 'Export ABIs to a node package').setAction(
+  async (_, { artifacts }) => {
     // get only relevant files
     const allContracts = await artifacts.getAllFullyQualifiedNames()
     const startsWith = (name: string) =>
@@ -57,4 +52,5 @@ task('export:abis', 'Export ABIs to a node package')
       path.resolve(packageFolder, 'src'),
       path.resolve(packageFolder, 'src', 'abis')
     )
-  })
+  }
+)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2846,7 +2846,6 @@ __metadata:
     pinst: "npm:3.0.0"
     prettier: "npm:3.4.2"
     prettier-plugin-solidity: "npm:1.4.2"
-    semver: "npm:7.6.3"
     solhint: "npm:5.0.5"
     solidity-coverage: "npm:0.8.14"
     solmate: "npm:6.8.0"
@@ -10861,15 +10860,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:7.6.3, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.2, semver@npm:^7.6.3":
-  version: 7.6.3
-  resolution: "semver@npm:7.6.3"
-  bin:
-    semver: bin/semver.js
-  checksum: 10/36b1fbe1a2b6f873559cd57b238f1094a053dbfd997ceeb8757d79d1d2089c56d1321b9f1069ce263dc64cfa922fa1d2ad566b39426fe1ac6c723c1487589e10
-  languageName: node
-  linkType: hard
-
 "semver@npm:^5.5.0":
   version: 5.7.2
   resolution: "semver@npm:5.7.2"
@@ -10885,6 +10875,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10/1ef3a85bd02a760c6ef76a45b8c1ce18226de40831e02a00bad78485390b98b6ccaa31046245fc63bba4a47a6a592b6c7eedc65cc47126e60489f9cc1ce3ed7e
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.5.2, semver@npm:^7.5.4, semver@npm:^7.6.0, semver@npm:^7.6.2, semver@npm:^7.6.3":
+  version: 7.6.3
+  resolution: "semver@npm:7.6.3"
+  bin:
+    semver: bin/semver.js
+  checksum: 10/36b1fbe1a2b6f873559cd57b238f1094a053dbfd997ceeb8757d79d1d2089c56d1321b9f1069ce263dc64cfa922fa1d2ad566b39426fe1ac6c723c1487589e10
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
we remove semver that was used for bumping version of the abi packages to prepare a future use of `yarn release` task