### PR TITLE
fix(backend): Fix pool name and symbol assignment

### DIFF
--- a/backend/ponder.schema.ts
+++ b/backend/ponder.schema.ts
@@ -4,17 +4,14 @@ import { index, onchainTable, primaryKey, relations } from 'ponder'
  * Track yield pools
  * - contractAddress: Contract address
  * - asset: Asset (token) address
- * - name: Pool name
- * - totalAssets: Total assets in pool
- * - totalShares: Total shares issued
- * - lastUpdated: Last time the pool was updated
+ * - name: Yield pool name
+ * - lastUpdated: Last time the yield pool was updated
  */
 export const yieldPool = onchainTable('yield_pool', (t) => ({
   contractAddress: t.hex().primaryKey(),
   asset: t.hex().notNull(),
   name: t.text().notNull(),
-  totalAssets: t.bigint().notNull(),
-  totalShares: t.bigint().notNull(),
+  symbol: t.text().notNull(),
   lastUpdated: t.bigint().notNull(),
 }))
 


### PR DESCRIPTION
This PR fixes a bug in the `PoolDeployed` event handler where pools were incorrectly assigned the third party’s name and symbol instead of their own. The fix ensures that both standard pools and yield pools use the right identifiers upon deployment.