### PR TITLE
fix(backend): Remove irrelevant references and optimize monorepo build

### DIFF
--- a/backend/ponder.schema.ts
+++ b/backend/ponder.schema.ts
@@ -11,7 +11,6 @@ export const yieldPool = onchainTable('yield_pool', (t) => ({
   contractAddress: t.hex().primaryKey(),
   asset: t.hex().notNull(),
   name: t.text().notNull(),
-  symbol: t.text().notNull(),
   lastUpdated: t.bigint().notNull(),
 }))
 

--- a/backend/src/handlers/RelayBridge/BridgeInitiated.ts
+++ b/backend/src/handlers/RelayBridge/BridgeInitiated.ts
@@ -13,8 +13,13 @@ export default async function ({
   const { nonce, sender, recipient, asset, amount, poolChainId, pool } =
     event.args
 
-  // Get Hyperlane dispatch event from the same transaction
-  const dispatchEvent = await getEvent(event.transaction, 'Dispatch', Mailbox)
+  // Ensure that the transaction object has a defined logs array
+  const tx = event.transaction || {}
+  tx.logs = tx.logs ?? []
+
+  // Get Hyperlane dispatch event from the same transaction if logs exist.
+  const dispatchEvent =
+    tx.logs.length > 0 ? await getEvent(tx, 'Dispatch', Mailbox) : null
   const hyperlaneMessageId = dispatchEvent ? dispatchEvent.args[0] : null
 
   // Record bridge initiation

--- a/backend/src/handlers/RelayPool/Withdraw.ts
+++ b/backend/src/handlers/RelayPool/Withdraw.ts
@@ -1,6 +1,5 @@
 import { Context, Event } from 'ponder:registry'
-import { poolAction, relayPool, userBalance, yieldPool } from 'ponder:schema'
-import { erc4626Abi } from 'viem'
+import { poolAction, relayPool, userBalance } from 'ponder:schema'
 
 export default async function ({
   event,
@@ -23,13 +22,8 @@ export default async function ({
     throw new Error(`Relay pool ${event.log.address} not found`)
   }
 
-  // Fetch current state from both pools
-  const [
-    relayTotalAssets,
-    relayTotalShares,
-    yieldTotalAssets,
-    yieldTotalShares,
-  ] = await Promise.all([
+  // Fetch current state from relay pool
+  const [relayTotalAssets, relayTotalShares] = await Promise.all([
     context.client.readContract({
       abi: context.contracts.RelayPool.abi,
       address: event.log.address,
@@ -38,33 +32,16 @@ export default async function ({
     context.client.readContract({
       abi: context.contracts.RelayPool.abi,
       address: event.log.address,
-      functionName: 'totalSupply',
-    }),
-    context.client.readContract({
-      abi: erc4626Abi,
-      address: pool.yieldPool,
-      functionName: 'totalAssets',
-    }),
-    context.client.readContract({
-      abi: erc4626Abi,
-      address: pool.yieldPool,
       functionName: 'totalSupply',
     }),
   ])
 
-  // Update both pools atomically
+  // Update states
   await Promise.all([
     // Update relay pool
     context.db.update(relayPool, { contractAddress: event.log.address }).set({
       totalAssets: relayTotalAssets,
       totalShares: relayTotalShares,
-    }),
-
-    // Update yield pool
-    context.db.update(yieldPool, { contractAddress: pool.yieldPool }).set({
-      totalAssets: yieldTotalAssets,
-      totalShares: yieldTotalShares,
-      lastUpdated: BigInt(timestamp),
     }),
 
     // Record pool action

--- a/backend/src/handlers/RelayPoolFactory/PoolDeployed.ts
+++ b/backend/src/handlers/RelayPoolFactory/PoolDeployed.ts
@@ -31,7 +31,7 @@ export default async function ({
     }),
   ])
 
-  // Upsert yield pool using only its name and symbol.
+  // Upsert yield pool using only its name.
   await context.db
     .insert(yieldPool)
     .values({

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "clean": "yarn packages:clean",
     "lint": "yarn packages --parallel run lint",
     "backend:dev": "yarn build && yarn workspace @relay-protocol/backend dev",
-    "backend:start": "yarn build && yarn workspace @relay-protocol/backend start"
+    "backend:start": "yarn workspace @relay-protocol/backend start"
   },
   "engines": {
     "node": "22"


### PR DESCRIPTION
This PR removes all references to totalAssets and shares in the yield pool, as they are not relevant. Additionally, it refactors our monorepo build script to improve build times.