### PR TITLE
feature(backend): `VaultSnapshot`

### DIFF
--- a/backend/ponder.config.ts
+++ b/backend/ponder.config.ts
@@ -95,7 +95,7 @@ export default createConfig({
     VaultSnapshot: {
       network: 'sepolia',
       startBlock: 7609300,
-      interval: 600, // ~2 hours with 12s block time
+      interval: 25, // ~5 minutes with 12s block time
     },
   },
 })

--- a/backend/ponder.config.ts
+++ b/backend/ponder.config.ts
@@ -91,4 +91,11 @@ export default createConfig({
       },
     },
   },
+  blocks: {
+    VaultSnapshot: {
+      network: 'sepolia',
+      startBlock: 7609300,
+      interval: 600, // ~2 hours with 12s block time
+    },
+  },
 })

--- a/backend/ponder.schema.ts
+++ b/backend/ponder.schema.ts
@@ -138,7 +138,7 @@ export const userBalanceRelations = relations(userBalance, ({ one }) => ({
  */
 export const relayPoolRelations = relations(relayPool, ({ many }) => ({
   userBalances: many(userBalance),
-  snapshots: many(vaultsnapshot),
+  snapshots: many(vaultSnapshot),
 }))
 
 export const relayBridge = onchainTable('relay_bridge', (t) => ({
@@ -228,7 +228,7 @@ export const bridgeTransaction = onchainTable(
  * - sharePrice: Share price at snapshot time, computed via convertToAssets(1e18)
  */
 export const vaultSnapshot = onchainTable(
-  'vaultsnapshot',
+  'vaultSnapshot',
   (t) => ({
     id: t.text().primaryKey(),
     vault: t.hex().notNull(),
@@ -272,9 +272,9 @@ export const bridgeTransactionOrigin = relations(
 )
 
 // Update the relation to include chainId in the join condition
-export const vaultSnapshotRelations = relations(vaultsnapshot, ({ one }) => ({
+export const vaultSnapshotRelations = relations(vaultSnapshot, ({ one }) => ({
   pool: one(relayPool, {
-    fields: [vaultsnapshot.vault, vaultsnapshot.chainId],
+    fields: [vaultSnapshot.vault, vaultSnapshot.chainId],
     references: [relayPool.contractAddress, relayPool.chainId],
   }),
 }))

--- a/backend/ponder.schema.ts
+++ b/backend/ponder.schema.ts
@@ -227,7 +227,7 @@ export const bridgeTransaction = onchainTable(
  * - timestamp: Block timestamp when the snapshot was taken
  * - sharePrice: Share price at snapshot time, computed via convertToAssets(1e18)
  */
-export const vaultsnapshot = onchainTable(
+export const vaultSnapshot = onchainTable(
   'vaultsnapshot',
   (t) => ({
     id: t.text().primaryKey(),

--- a/backend/src/intervals/VaultSnapshot.ts
+++ b/backend/src/intervals/VaultSnapshot.ts
@@ -1,0 +1,62 @@
+/**
+ * Vault Snapshot Handler
+ *
+ * This interval handler captures periodic snapshots of vault share prices at configured block intervals.
+ * The snapshots track vault performance over time by recording share price history.
+ *
+ * For each vault (relay pool), it:
+ * 1. Queries the current share price by calling convertToAssets(1e18) on the ERC4626 vault
+ * 2. Creates a unique snapshot ID by combining the vault address and block number
+ * 3. Records the snapshot with block metadata in the vaultsnapshot table
+ *
+ * The interval between snapshots is configured in ponder.config.ts via the VaultSnapshot block interval.
+ * This provides a time series of share prices that can be used to analyze vault returns and performance.
+ */
+
+import { ponder } from 'ponder:registry'
+import { vaultsnapshot, relayPool } from 'ponder:schema'
+
+ponder.on('VaultSnapshot:block', async ({ event, context }) => {
+  console.log(
+    '[VaultSnapshot] Processing block ' +
+      event.block.number +
+      ' at timestamp ' +
+      event.block.timestamp
+  )
+
+  const vaults = await context.db.sql.select().from(relayPool).execute()
+  console.log('[VaultSnapshot] Found ' + vaults.length + ' vaults to process')
+
+  for (const vault of vaults) {
+    console.log(
+      '[VaultSnapshot] Processing vault ' + vault.contractAddress + ':'
+    )
+
+    const sharePrice = await context.client.readContract({
+      address: vault.contractAddress,
+      abi: context.contracts.RelayPool.abi,
+      functionName: 'convertToAssets',
+      args: [BigInt('1000000000000000000')], // 1e18
+    })
+
+    console.log('  - Computed Share Price: ' + sharePrice.toString())
+
+    // unique ID by combining vault address and block number
+    const id = `${vault.contractAddress.toLowerCase()}-${event.block.number}`
+
+    const snapshot = {
+      id,
+      vault: vault.contractAddress,
+      blockNumber: event.block.number,
+      timestamp: event.block.timestamp,
+      sharePrice: sharePrice.toString(),
+    }
+
+    await context.db.insert(vaultsnapshot).values(snapshot)
+    console.log('  - Saved new vault snapshot to database')
+  }
+
+  console.log(
+    '[VaultSnapshot] Completed processing block ' + event.block.number
+  )
+})

--- a/backend/src/intervals/VaultSnapshot.ts
+++ b/backend/src/intervals/VaultSnapshot.ts
@@ -38,12 +38,13 @@ ponder.on('VaultSnapshot:block', async ({ event, context }) => {
       args: [shareUnit],
     })
 
-    // Create a unique snapshot ID by combining the vault address and block number.
-    const id = `${vault.contractAddress.toLowerCase()}-${event.block.number}`
+    // Create a unique snapshot ID by combining chainId, vault address and block number
+    const id = `${vault.chainId}-${vault.contractAddress.toLowerCase()}-${event.block.number}`
 
     const snapshot = {
       id,
       vault: vault.contractAddress,
+      chainId: vault.chainId,
       blockNumber: event.block.number,
       timestamp: event.block.timestamp,
       sharePrice: sharePrice.toString(),

--- a/backend/src/intervals/VaultSnapshot.ts
+++ b/backend/src/intervals/VaultSnapshot.ts
@@ -7,14 +7,14 @@
  * For each vault (relay pool), it:
  * 1. Queries the current share price by calling convertToAssets(10^vaultDecimals) on the ERC4626 vault
  * 2. Creates a unique snapshot ID by combining the vault address and block number
- * 3. Records the snapshot with block metadata in the vaultsnapshot table
+ * 3. Records the snapshot with block metadata in the vaultSnapshot table
  *
  * The interval between snapshots is configured in ponder.config.ts via the VaultSnapshot block interval.
  * This provides a time series of share prices that can be used to analyze vault returns and performance.
  */
 
 import { ponder } from 'ponder:registry'
-import { vaultsnapshot, relayPool } from 'ponder:schema'
+import { vaultSnapshot, relayPool } from 'ponder:schema'
 
 ponder.on('VaultSnapshot:block', async ({ event, context }) => {
   const vaults = await context.db.sql.select().from(relayPool).execute()
@@ -50,6 +50,6 @@ ponder.on('VaultSnapshot:block', async ({ event, context }) => {
       sharePrice: sharePrice.toString(),
     }
 
-    await context.db.insert(vaultsnapshot).values(snapshot)
+    await context.db.insert(vaultSnapshot).values(snapshot)
   }
 })


### PR DESCRIPTION
This PR introduces a handler that captures periodic share price snapshots for pools at configured block intervals, enabling time-series analysis of a vault's performance. The snapshot interval is configurable via `ponder.config.ts`.

### Example Query

```graphql
query GetPoolDetails($poolAddress: String!) {
  relayPool(contractAddress: $poolAddress) {
    yieldPool
    contractAddress
    chainId
    asset
    totalAssets
    totalShares
    outstandingDebt
    snapshots(limit: 10, orderBy: "blockNumber", orderDirection: "desc") {
      items {
        vault
        blockNumber
        timestamp
        sharePrice
      }
    }
    origins(limit: 10) {
      totalCount
      items {
        proxyBridge
        originChainId
        originBridge
        maxDebt
      }
    }
  }
}
```