### PR TITLE
feat(smart-contracts): timelock template deployment

### DIFF
--- a/smart-contracts/ignition/modules/RelayPoolFactoryModule.ts
+++ b/smart-contracts/ignition/modules/RelayPoolFactoryModule.ts
@@ -1,14 +1,17 @@
 import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
+import TimelockTemplateModule from './TimelockTemplateModule'
 
 export default buildModule('RelayPoolFactory', (m) => {
   const hyperlaneMailbox = m.getParameter('hyperlaneMailbox')
   const weth = m.getParameter('weth')
-  const timelock = m.getParameter('timelock')
+
+  // Deploy timelock template as part of the factory init
+  const { timelockTemplate } = m.useModule(TimelockTemplateModule)
 
   const relayPoolFactory = m.contract('RelayPoolFactory', [
     hyperlaneMailbox,
     weth,
-    timelock,
+    timelockTemplate,
   ])
-  return { relayPoolFactory }
+  return { relayPoolFactory, timelockTemplate }
 })

--- a/smart-contracts/ignition/modules/TimelockTemplateModule.ts
+++ b/smart-contracts/ignition/modules/TimelockTemplateModule.ts
@@ -2,7 +2,8 @@ import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
 import { ZeroAddress } from 'ethers'
 
 export default buildModule('TimelockTemplateModule', (m) => {
-  const timelockTemplate = m.contract('TimelockControllerUpgradeable', [
+  const timelockTemplate = m.contract('TimelockControllerUpgradeable')
+  m.call(timelockTemplate, 'initialize', [
     0, // minDelay
     [], // proposers
     [], // executors

--- a/smart-contracts/ignition/modules/TimelockTemplateModule.ts
+++ b/smart-contracts/ignition/modules/TimelockTemplateModule.ts
@@ -1,0 +1,12 @@
+import { buildModule } from '@nomicfoundation/hardhat-ignition/modules'
+import { ZeroAddress } from 'ethers'
+
+export default buildModule('TimelockTemplateModule', (m) => {
+  const timelockTemplate = m.contract('TimelockControllerUpgradeable', [
+    0, // minDelay
+    [], // proposers
+    [], // executors
+    ZeroAddress, // admin
+  ])
+  return { timelockTemplate }
+})

--- a/smart-contracts/test/RelayPool/inflation-attack.hardhat.ts
+++ b/smart-contracts/test/RelayPool/inflation-attack.hardhat.ts
@@ -4,6 +4,7 @@ import networks from '@relay-protocol/networks'
 import { MyToken, MyYieldPool, RelayPool } from '../../typechain-types'
 import RelayPoolFactoryModule from '../../ignition/modules/RelayPoolFactoryModule'
 import { getEvent } from '@relay-protocol/helpers'
+import TimelockTemplateModule from '../../ignition/modules/TimelockTemplateModule'
 
 describe('RelayPool: inflation attack', () => {
   let relayPool: RelayPool
@@ -38,11 +39,7 @@ describe('RelayPool: inflation attack', () => {
     expect(await myToken.totalSupply()).to.equal('1000000000000000000000000000')
 
     // Deploy an "empty" timelock for the Pool Factory
-    const TimelockController = await ethers.getContractFactory(
-      'TimelockControllerUpgradeable'
-    )
-    const timelockTemplate = await TimelockController.deploy()
-    await timelockTemplate.waitForDeployment()
+    const { timelockTemplate } = await ignition.deploy(TimelockTemplateModule)
 
     // Deploy the factory
     const { relayPoolFactory } = await ignition.deploy(RelayPoolFactoryModule, {

--- a/smart-contracts/test/RelayPool/inflation-attack.hardhat.ts
+++ b/smart-contracts/test/RelayPool/inflation-attack.hardhat.ts
@@ -4,7 +4,6 @@ import networks from '@relay-protocol/networks'
 import { MyToken, MyYieldPool, RelayPool } from '../../typechain-types'
 import RelayPoolFactoryModule from '../../ignition/modules/RelayPoolFactoryModule'
 import { getEvent } from '@relay-protocol/helpers'
-import TimelockTemplateModule from '../../ignition/modules/TimelockTemplateModule'
 
 describe('RelayPool: inflation attack', () => {
   let relayPool: RelayPool
@@ -38,16 +37,12 @@ describe('RelayPool: inflation attack', () => {
     // Check that there are shares!
     expect(await myToken.totalSupply()).to.equal('1000000000000000000000000000')
 
-    // Deploy an "empty" timelock for the Pool Factory
-    const { timelockTemplate } = await ignition.deploy(TimelockTemplateModule)
-
     // Deploy the factory
     const { relayPoolFactory } = await ignition.deploy(RelayPoolFactoryModule, {
       parameters: {
         RelayPoolFactory: {
           hyperlaneMailbox: networks[1].hyperlaneMailbox,
           weth: ethers.ZeroAddress,
-          timelock: await timelockTemplate.getAddress(),
         },
       },
       deploymentId: 'RelayPoolFactory',

--- a/smart-contracts/test/RelayPool/inflation-attack.hardhat.ts
+++ b/smart-contracts/test/RelayPool/inflation-attack.hardhat.ts
@@ -93,7 +93,7 @@ describe('RelayPool: inflation attack', () => {
     // Then send a LARGE amount of tokens to the third party pool
     const attackAmount = ethers.parseUnits('100', await myToken.decimals())
     myToken.connect(attacker).mint(attackAmount)
-    myToken
+    await myToken
       .connect(attacker)
       .approve(await thirdPartyPool.getAddress(), attackAmount)
     await thirdPartyPool

--- a/smart-contracts/test/RelayPoolFactory/initialization.hardhat.ts
+++ b/smart-contracts/test/RelayPoolFactory/initialization.hardhat.ts
@@ -3,6 +3,7 @@ import { ethers, ignition } from 'hardhat'
 import { MyToken, MyYieldPool, RelayPoolFactory } from '../../typechain-types'
 import RelayPoolFactoryModule from '../../ignition/modules/RelayPoolFactoryModule'
 import { getEvent } from '@relay-protocol/helpers'
+import TimelockTemplateModule from '../../ignition/modules/TimelockTemplateModule'
 
 describe('RelayPoolFactory: deployment', () => {
   let relayPoolFactory: RelayPoolFactory
@@ -39,11 +40,7 @@ describe('RelayPoolFactory: deployment', () => {
     expect(await myToken.totalSupply()).to.equal('1000000000000000000000000000')
 
     // Deploy an "empty" timelock for the Pool Factory
-    const TimelockController = await ethers.getContractFactory(
-      'TimelockControllerUpgradeable'
-    )
-    timelockTemplate = await TimelockController.deploy()
-    await timelockTemplate.waitForDeployment()
+    const { timelockTemplate } = await ignition.deploy(TimelockTemplateModule)
 
     // Deploy the factory
     ;({ relayPoolFactory } = await ignition.deploy(RelayPoolFactoryModule, {

--- a/smart-contracts/test/RelayPoolFactory/initialization.hardhat.ts
+++ b/smart-contracts/test/RelayPoolFactory/initialization.hardhat.ts
@@ -1,14 +1,18 @@
 import { expect } from 'chai'
 import { ethers, ignition } from 'hardhat'
-import { MyToken, MyYieldPool, RelayPoolFactory } from '../../typechain-types'
+import {
+  MyToken,
+  MyYieldPool,
+  RelayPoolFactory,
+  TimelockControllerUpgradeable,
+} from '../../typechain-types'
 import RelayPoolFactoryModule from '../../ignition/modules/RelayPoolFactoryModule'
 import { getEvent } from '@relay-protocol/helpers'
-import TimelockTemplateModule from '../../ignition/modules/TimelockTemplateModule'
 
 describe('RelayPoolFactory: deployment', () => {
   let relayPoolFactory: RelayPoolFactory
   let myToken: MyToken
-  let timelockTemplate: any
+  let timelockTemplate: TimelockControllerUpgradeable
   const hyperlaneMailbox = '0x1000000000000000000000000000000000000000'
   const weth = '0x2000000000000000000000000000000000000000'
   let thirdPartyPool: MyYieldPool
@@ -39,20 +43,19 @@ describe('RelayPoolFactory: deployment', () => {
     // Check that there are shares!
     expect(await myToken.totalSupply()).to.equal('1000000000000000000000000000')
 
-    // Deploy an "empty" timelock for the Pool Factory
-    const { timelockTemplate } = await ignition.deploy(TimelockTemplateModule)
-
     // Deploy the factory
-    ;({ relayPoolFactory } = await ignition.deploy(RelayPoolFactoryModule, {
-      parameters: {
-        RelayPoolFactory: {
-          hyperlaneMailbox,
-          weth,
-          timelock: await timelockTemplate.getAddress(),
+    ;({ relayPoolFactory, timelockTemplate } = await ignition.deploy(
+      RelayPoolFactoryModule,
+      {
+        parameters: {
+          RelayPoolFactory: {
+            hyperlaneMailbox,
+            weth,
+          },
         },
-      },
-      deploymentId: 'RelayPoolFactory',
-    }))
+        deploymentId: 'RelayPoolFactory',
+      }
+    ))
   })
 
   it('should have deployed the factory', async () => {


### PR DESCRIPTION
To avoid mistakes, makes the timelock template part of the pool factory deployment