### PR TITLE
make zksync bridge nonpayable

### DIFF
--- a/smart-contracts/contracts/BridgeProxy/ZkSyncBridgeProxy.sol
+++ b/smart-contracts/contracts/BridgeProxy/ZkSyncBridgeProxy.sol
@@ -24,7 +24,7 @@ contract ZkSyncBridgeProxy is BridgeProxy {
     address /* l1Asset */,
     uint256 amount,
     bytes calldata /*data*/
-  ) external payable override {
+  ) external override {
     // withdraw to L1
     L2_SHARED_BRIDGE.withdraw(L1_BRIDGE_PROXY, currency, amount);
   }


### PR DESCRIPTION
zksync bridge has currently no support for native tokens bridging so making the function nonpayable for now. 

NB: this may be changed back in a future PR when zksync native support is added 