### PR TITLE
swap requires a minimum amount of tokens out

### DIFF
--- a/smart-contracts/contracts/RelayPool.sol
+++ b/smart-contracts/contracts/RelayPool.sol
@@ -488,7 +488,8 @@ contract RelayPool is ERC4626, Ownable {
     uint256 amount,
     uint24 uniswapWethPoolFeeToken,
     uint24 uniswapWethPoolFeeAsset,
-    uint48 deadline
+    uint48 deadline,
+    uint256 amountOutMinimum
   ) public onlyOwner {
     if (token == address(asset)) {
       revert UnauthorizedSwap(token);
@@ -499,7 +500,8 @@ contract RelayPool is ERC4626, Ownable {
       token,
       uniswapWethPoolFeeToken,
       uniswapWethPoolFeeAsset,
-      deadline
+      deadline,
+      amountOutMinimum
     );
     collectNonDepositedAssets();
   }

--- a/smart-contracts/contracts/TokenSwap.sol
+++ b/smart-contracts/contracts/TokenSwap.sol
@@ -75,12 +75,14 @@ contract TokenSwap {
    * @notice The default route is token > WETH > asset.
    * If `uniswapWethPoolFeeAsset` is set to null, then we do a direct swap token > asset
    * @param deadline The deadline for the swap transaction
+   * @param amountOutMinimum The minimum amount of output tokens that must be received for the transaction not to revert
    */
   function swap(
     address tokenAddress,
     uint24 uniswapWethPoolFeeToken,
     uint24 uniswapWethPoolFeeAsset,
-    uint48 deadline
+    uint48 deadline,
+    uint256 amountOutMinimum
   ) public payable returns (uint256 amountOut) {
     // get info from pool
     address pool = msg.sender;
@@ -129,7 +131,7 @@ contract TokenSwap {
     inputs[0] = abi.encode(
       address(this), // recipient is this contract
       tokenAmount, // amountIn
-      0, // amountOutMinimum
+      amountOutMinimum, // amountOutMinimum
       path,
       true // funds are not coming from PERMIT2
     );

--- a/smart-contracts/contracts/interfaces/ITokenSwap.sol
+++ b/smart-contracts/contracts/interfaces/ITokenSwap.sol
@@ -6,6 +6,7 @@ interface ITokenSwap {
     address pool,
     uint24 uniswapWethPoolFeeToken,
     uint24 uniswapWethPoolFeeAsset,
-    uint48 deadline
+    uint48 deadline,
+    uint256 amountOutMinimum
   ) external payable returns (uint amount);
 }

--- a/smart-contracts/test/RelayPool/swap-and-deposit.ethereum.ts
+++ b/smart-contracts/test/RelayPool/swap-and-deposit.ethereum.ts
@@ -50,7 +50,8 @@ const tokenSwapBehavior = async (
     amount,
     tokenPoolFee,
     assetPoolFee,
-    deadline
+    deadline,
+    0 // amountOutMinimum - setting to 0 for tests since we're not concerned with slippage
   )
 
   const receipt = await tx.wait()
@@ -134,15 +135,14 @@ describe('RelayPool / Swap and Deposit', () => {
 
   it('can only be called by contract owner', async () => {
     await reverts(
-      relayPool
-        .connect(attacker)
-        .swapAndDeposit(
-          ZeroAddress,
-          1000,
-          1000,
-          1000,
-          Math.floor(Date.now() / 1000) + 300
-        ),
+      relayPool.connect(attacker).swapAndDeposit(
+        ZeroAddress,
+        1000,
+        1000,
+        1000,
+        Math.floor(Date.now() / 1000) + 300,
+        0 // amountOutMinimum
+      ),
       `OwnableUnauthorizedAccount("${await attacker.getAddress()}")`
     )
   })


### PR DESCRIPTION
To prevent sandwich attacks, the swap function now requires curator to specify a minimum amount of tokens out.