### PR TITLE
Automatically update addresses package

### DIFF
--- a/packages/addresses/bin/generateAddressFile.ts
+++ b/packages/addresses/bin/generateAddressFile.ts
@@ -3,51 +3,131 @@ import path from 'path'
 import { getProvider } from '@relay-protocol/helpers'
 
 interface Addresses {
-  [address: string]: any
-}
-
-const addresses: Addresses = {}
-
-const basePath = __dirname + '/../../../smart-contracts/ignition/deployments/'
-export const getAddressForFile = (file: string) => {
-  const deployments = JSON.parse(fs.readFileSync(basePath + file, 'utf-8'))
-  return Object.values(deployments)[0]
-}
-
-// export const getDeployBlock = async (address, chainID) => {}
-
-export const getAddresses = () => {
-  fs.readdirSync(basePath).forEach((file) => {
-    let match
-    if ((match = file.match(/BridgeProxy-(?<bridge>.*)-(?<chainId>.*)/))) {
-      addresses[match.groups!.chainId] ||= {}
-      addresses[match.groups!.chainId].BridgeProxy ||= {}
-      const address = getAddressForFile(file + '/deployed_addresses.json')
-      if (address) {
-        addresses[match.groups!.chainId].BridgeProxy[match.groups!.bridge] =
-          address
-      }
-    } else if ((match = file.match(/RelayBridgeFactory-(?<chainId>.*)/))) {
-      addresses[match.groups!.chainId] ||= {}
-      const address = getAddressForFile(file + '/deployed_addresses.json')
-      if (address) {
-        addresses[match.groups!.chainId].RelayBridgeFactory = address
-      }
-    } else if ((match = file.match(/RelayPoolFactory-(?<chainId>.*)/))) {
-      addresses[match.groups!.chainId] ||= {}
-      const address = getAddressForFile(file + '/deployed_addresses.json')
-      if (address) {
-        addresses[match.groups!.chainId].RelayPoolFactory = address
-      }
+  [chainId: string]: {
+    BridgeProxy?: {
+      [bridgeType: string]: string
     }
-  })
+    RelayBridgeFactory?: string
+    RelayPoolFactory?: string
+    [key: string]: any
+  }
+}
+
+// Base path to ignition deployments
+const DEPLOYMENTS_PATH = path.resolve(
+  __dirname,
+  '../../../smart-contracts/ignition/deployments/'
+)
+
+/**
+ * Extract contract address from deployment file
+ */
+function getAddressFromDeployment(deploymentPath: string): string | null {
+  try {
+    const filePath = path.join(
+      DEPLOYMENTS_PATH,
+      deploymentPath,
+      'deployed_addresses.json'
+    )
+    if (!fs.existsSync(filePath)) return null
+
+    const deployment = JSON.parse(fs.readFileSync(filePath, 'utf-8'))
+    return Object.values(deployment)[0] as string
+  } catch (error) {
+    console.error(`Error reading deployment file ${deploymentPath}:`, error)
+    return null
+  }
+}
+
+/**
+ * Scan all deployments and build addresses object
+ */
+export function getAddresses(): Addresses {
+  const addresses: Addresses = {}
+
+  // Get all deployment directories
+  const deploymentDirs = fs.readdirSync(DEPLOYMENTS_PATH)
+
+  // Process each deployment
+  for (const dir of deploymentDirs) {
+    // BridgeProxy deployments (format: BridgeProxy-{bridgeType}-{chainId})
+    const bridgeProxyMatch = dir.match(
+      /BridgeProxy-(?<bridge>.*)-(?<chainId>.*)/
+    )
+    if (bridgeProxyMatch?.groups) {
+      const { bridge, chainId } = bridgeProxyMatch.groups
+
+      // Initialize chain entry if needed
+      addresses[chainId] = addresses[chainId] || {}
+      addresses[chainId].BridgeProxy = addresses[chainId].BridgeProxy || {}
+
+      // Get and store address
+      const address = getAddressFromDeployment(dir)
+      if (address) {
+        addresses[chainId].BridgeProxy[bridge] = address
+      }
+      continue
+    }
+
+    // RelayBridgeFactory deployments (format: RelayBridgeFactory-{chainId})
+    const bridgeFactoryMatch = dir.match(/RelayBridgeFactory-(?<chainId>.*)/)
+    if (bridgeFactoryMatch?.groups) {
+      const { chainId } = bridgeFactoryMatch.groups
+
+      // Initialize chain entry if needed
+      addresses[chainId] = addresses[chainId] || {}
+
+      // Get and store address
+      const address = getAddressFromDeployment(dir)
+      if (address) {
+        addresses[chainId].RelayBridgeFactory = address
+      }
+      continue
+    }
+
+    // RelayPoolFactory deployments (format: RelayPoolFactory-{chainId})
+    const poolFactoryMatch = dir.match(/RelayPoolFactory-(?<chainId>.*)/)
+    if (poolFactoryMatch?.groups) {
+      const { chainId } = poolFactoryMatch.groups
+
+      // Initialize chain entry if needed
+      addresses[chainId] = addresses[chainId] || {}
+
+      // Get and store address
+      const address = getAddressFromDeployment(dir)
+      if (address) {
+        addresses[chainId].RelayPoolFactory = address
+      }
+      continue
+    }
+  }
+
   return addresses
 }
 
-const generateAddressFile = async () => {
-  const addresses = getAddresses()
-  const abiFileName = path.resolve('src', 'addresses.json')
-  await fs.outputJSON(abiFileName, addresses, { spaces: 2 })
+/**
+ * Generate addresses file
+ */
+async function generateAddressFile() {
+  try {
+    // Get addresses from deployments
+    const addresses = getAddresses()
+
+    // Write to addresses.json
+    const outputPath = path.resolve(__dirname, '../src/addresses.json')
+    await fs.outputJSON(outputPath, addresses, { spaces: 2 })
+
+    console.log(`✅ Successfully generated addresses file at ${outputPath}`)
+  } catch (error) {
+    console.error('❌ Error generating addresses file:', error)
+    process.exit(1)
+  }
 }
 
-generateAddressFile()
+// Run if called directly
+if (require.main === module) {
+  generateAddressFile()
+}
+
+// Export for use in other scripts
+export { generateAddressFile }

--- a/smart-contracts/hardhat.config.ts
+++ b/smart-contracts/hardhat.config.ts
@@ -26,6 +26,8 @@ import './tasks/deploy/native-gateway'
 import './tasks/deploy/dummy-yield-pool'
 import './tasks/utils/exportAbis'
 import './tasks/utils/zksync-contracts.ts'
+import './tasks/utils/updateAddresses'
+import './tasks/utils/taskHooks'
 
 // get pk from shell
 const { DEPLOYER_PRIVATE_KEY } = process.env

--- a/smart-contracts/tasks/utils/taskHooks.ts
+++ b/smart-contracts/tasks/utils/taskHooks.ts
@@ -1,0 +1,43 @@
+import { task, subtask } from 'hardhat/config'
+import { TASK_COMPILE_SOLIDITY_COMPILE_JOBS } from 'hardhat/builtin-tasks/task-names'
+import './updateAddresses'
+
+/**
+ * This mdoule adds post-deployment hooks to automatically update addresses
+ * after deployment tasks complete
+ */
+
+// List of deployment tasks that should trigger address updates
+const DEPLOYMENT_TASKS = [
+  'deploy:pool-factory',
+  'deploy:bridge-factory',
+  'deploy:bridge-proxy',
+]
+
+// Add post-task hooks for each deployment task
+for (const deployTask of DEPLOYMENT_TASKS) {
+  subtask(`${deployTask}:post`).setAction(async (_, { run }) => {
+    console.log(
+      `\nDeployment task "${deployTask}" completed. Updating addresses...`
+    )
+    await run('utils:update-addresses')
+  })
+
+  // Override each deployment task to run the post-task
+  task(deployTask).setAction(async (args, hre, runSuper) => {
+    // Run the original task
+    const result = await runSuper(args)
+
+    // Run the post-task
+    try {
+      await hre.run(`${deployTask}:post`)
+    } catch (error) {
+      console.warn(
+        '\nWarning: Failed to update addresses after deployment:',
+        error
+      )
+    }
+
+    return result
+  })
+}

--- a/smart-contracts/tasks/utils/taskHooks.ts
+++ b/smart-contracts/tasks/utils/taskHooks.ts
@@ -1,13 +1,12 @@
-import { task, subtask } from 'hardhat/config'
-import { TASK_COMPILE_SOLIDITY_COMPILE_JOBS } from 'hardhat/builtin-tasks/task-names'
-import './updateAddresses'
-
 /**
  * This mdoule adds post-deployment hooks to automatically update addresses
  * after deployment tasks complete
  */
+import { task, subtask } from 'hardhat/config'
+import { TASK_COMPILE_SOLIDITY_COMPILE_JOBS } from 'hardhat/builtin-tasks/task-names'
+import './updateAddresses'
 
-// List of deployment tasks that should trigger address updates
+// List of deployment tasks triggers address package updates
 const DEPLOYMENT_TASKS = [
   'deploy:pool-factory',
   'deploy:bridge-factory',

--- a/smart-contracts/tasks/utils/updateAddresses.ts
+++ b/smart-contracts/tasks/utils/updateAddresses.ts
@@ -1,0 +1,33 @@
+import { task } from 'hardhat/config'
+import fs from 'fs-extra'
+import path from 'path'
+import { execSync } from 'child_process'
+
+/**
+ * Task to update the addresses package with the latest deployed contract addresses
+ * This can be called directly or hooked into deployment tasks
+ */
+task(
+  'utils:update-addresses',
+  'Update addresses package with latest deployments'
+).setAction(async (_, { config }) => {
+  console.log('Updating addresses package with latest deployments...')
+
+  try {
+    // Path to the addresses package
+    const addressesPackagePath = path.resolve(
+      config.paths.root,
+      '../packages/addresses'
+    )
+
+    // Run the generate script directly
+    execSync('yarn generate', {
+      cwd: addressesPackagePath,
+      stdio: 'inherit',
+    })
+
+    console.log('✅ Addresses package updated successfully')
+  } catch (error) {
+    console.error('❌ Failed to update addresses package:', error)
+  }
+})


### PR DESCRIPTION
This adds a `utils:update-addresses` task that will be triggered automatically (as a hook) after all deploy tasks so the addresses package is always up-to-date (for factories)