### PR TITLE
feat(smart-contracts) Dynamic l1 gas

### DIFF
--- a/smart-contracts/contracts/RelayBridge.sol
+++ b/smart-contracts/contracts/RelayBridge.sol
@@ -14,7 +14,8 @@ interface IRelayBridge {
   function bridge(
     uint256 amount,
     address recipient,
-    address l1Asset
+    address l1Asset,
+    uint256 l1Gas
   ) external payable returns (uint256 nonce);
 }
 
@@ -55,7 +56,7 @@ contract RelayBridge is IRelayBridge {
   function getFee(
     uint256 amount,
     address recipient,
-    uint256 l1Gas,
+    uint256 l1Gas
   ) external view returns (uint256 fee) {
     bytes memory data = abi.encode(
       transferNonce, // use the current transferNonce
@@ -81,7 +82,7 @@ contract RelayBridge is IRelayBridge {
     uint256 amount,
     address recipient,
     address l1Asset,
-    uint256 l1Gas,
+    uint256 l1Gas
   ) external payable returns (uint256 nonce) {
     // Associate the withdrawal to a unique id
     nonce = transferNonce++;

--- a/smart-contracts/contracts/RelayBridge.sol
+++ b/smart-contracts/contracts/RelayBridge.sol
@@ -19,8 +19,6 @@ interface IRelayBridge {
 }
 
 contract RelayBridge is IRelayBridge {
-  uint256 public constant IGP_GAS_LIMIT = 300_000;
-
   uint256 public transferNonce;
   address public immutable ASSET;
   BridgeProxy public immutable BRIDGE_PROXY;
@@ -56,7 +54,8 @@ contract RelayBridge is IRelayBridge {
   /// @return fee The required fee in native currency
   function getFee(
     uint256 amount,
-    address recipient
+    address recipient,
+    uint256 l1Gas,
   ) external view returns (uint256 fee) {
     bytes memory data = abi.encode(
       transferNonce, // use the current transferNonce
@@ -73,7 +72,7 @@ contract RelayBridge is IRelayBridge {
         poolChainId,
         poolId,
         data,
-        StandardHookMetadata.overrideGasLimit(IGP_GAS_LIMIT)
+        StandardHookMetadata.overrideGasLimit(l1Gas)
       );
   }
 
@@ -81,7 +80,8 @@ contract RelayBridge is IRelayBridge {
   function bridge(
     uint256 amount,
     address recipient,
-    address l1Asset
+    address l1Asset,
+    uint256 l1Gas,
   ) external payable returns (uint256 nonce) {
     // Associate the withdrawal to a unique id
     nonce = transferNonce++;
@@ -97,7 +97,7 @@ contract RelayBridge is IRelayBridge {
       poolChainId,
       poolId,
       data,
-      StandardHookMetadata.overrideGasLimit(IGP_GAS_LIMIT)
+      StandardHookMetadata.overrideGasLimit(l1Gas)
     );
 
     // Get the funds. If the L2 is halted/reorged, the funds will remain in this contract
@@ -135,7 +135,7 @@ contract RelayBridge is IRelayBridge {
       poolChainId,
       poolId,
       data,
-      StandardHookMetadata.overrideGasLimit(IGP_GAS_LIMIT)
+      StandardHookMetadata.overrideGasLimit(l1Gas)
     );
 
     emit BridgeInitiated(

--- a/smart-contracts/test/BridgeProxy/CCTPBridgeProxy.optimism.ts
+++ b/smart-contracts/test/BridgeProxy/CCTPBridgeProxy.optimism.ts
@@ -53,7 +53,7 @@ describe('CCTPBridgeProxy', function () {
           networks[10].assets.udt,
           networks[1].assets.udt,
           parseUnits('100', 6),
-          '0x' //empty data
+          '0x' //empty data,
         ),
         'TokenNotBridged'
       )

--- a/smart-contracts/test/RelayBridge/bridging.optimism.ts
+++ b/smart-contracts/test/RelayBridge/bridging.optimism.ts
@@ -13,6 +13,7 @@ const { hyperlaneMailbox: HYPERLANE_MAILBOX_ON_OPTIMISM } = networks[10]
 
 const relayPool = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
 const l1BridgeProxy = '0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1'
+const l1Gas = '500000'
 
 // This runs in an OP fork because we need Hyperlane to work, but we don't actually use the OPStack native bridge.
 describe('RelayBridge', function () {
@@ -49,10 +50,16 @@ describe('RelayBridge', function () {
       const amount = ethers.parseEther('1')
       const nonce = await bridge.transferNonce()
       const balanceBefore = await getBalance(recipient, ethers.provider)
-      const fee = await bridge.getFee(amount, recipient)
-      const tx = await bridge.bridge(amount, recipient, ethers.ZeroAddress, {
-        value: amount + fee,
-      })
+      const fee = await bridge.getFee(amount, recipient, l1Gas)
+      const tx = await bridge.bridge(
+        amount,
+        recipient,
+        ethers.ZeroAddress,
+        l1Gas,
+        {
+          value: amount + fee,
+        }
+      )
       const receipt = await tx.wait()
 
       const bridgeAddress = await bridge.getAddress()
@@ -89,10 +96,10 @@ describe('RelayBridge', function () {
 
       const recipient = await user.getAddress()
       const amount = ethers.parseEther('1')
-      const fee = await bridge.getFee(amount, recipient)
+      const fee = await bridge.getFee(amount, recipient, l1Gas)
 
       await expect(
-        bridge.bridge(amount, recipient, ethers.ZeroAddress, {
+        bridge.bridge(amount, recipient, ethers.ZeroAddress, l1Gas, {
           value: amount / 2n,
         })
       )
@@ -105,11 +112,11 @@ describe('RelayBridge', function () {
       const recipient = await user.getAddress()
       const amount = 13371337133713371337n
 
-      const fee = await bridge.getFee(amount, recipient)
+      const fee = await bridge.getFee(amount, recipient, l1Gas)
       const wethAddressOnL1 = ethers.ZeroAddress
 
       await expect(
-        bridge.bridge(amount, recipient, wethAddressOnL1, {
+        bridge.bridge(amount, recipient, wethAddressOnL1, l1Gas, {
           value: amount + fee,
         })
       ).to.be.revertedWithCustomError(bridge, 'BridgingFailed')
@@ -121,12 +128,12 @@ describe('RelayBridge', function () {
       const recipient = await user.getAddress()
       const amount = ethers.parseEther('1')
       const balanceBefore = await getBalance(recipient, ethers.provider)
-      const fee = await bridge.getFee(amount, recipient)
+      const fee = await bridge.getFee(amount, recipient, l1Gas)
 
       const value = (amount + fee) * 10n
       const expectedBalanceAfter = balanceBefore - value
 
-      await bridge.bridge(amount, recipient, ethers.ZeroAddress, {
+      await bridge.bridge(amount, recipient, ethers.ZeroAddress, l1Gas, {
         value,
       })
 
@@ -175,13 +182,19 @@ describe('RelayBridge', function () {
       const nonce = await bridge.transferNonce()
       const balanceBefore = await weth.balanceOf(recipient)
 
-      const fee = await bridge.getFee(amount, recipient)
+      const fee = await bridge.getFee(amount, recipient, l1Gas)
       const wethAddress = await weth.getAddress()
       const wethAddressOnL1 = ethers.ZeroAddress
 
-      const tx = await bridge.bridge(amount, recipient, wethAddressOnL1, {
-        value: fee,
-      })
+      const tx = await bridge.bridge(
+        amount,
+        recipient,
+        wethAddressOnL1,
+        l1Gas,
+        {
+          value: fee,
+        }
+      )
       const receipt = await tx.wait()
 
       expect(receipt.logs.length).to.equal(6)
@@ -227,11 +240,11 @@ describe('RelayBridge', function () {
       // Approve
       await weth.approve(bridgeAddress, amount / 2n)
 
-      const fee = await bridge.getFee(amount, recipient)
+      const fee = await bridge.getFee(amount, recipient, l1Gas)
       const wethAddressOnL1 = ethers.ZeroAddress
 
       await expect(
-        bridge.bridge(amount, recipient, wethAddressOnL1, {
+        bridge.bridge(amount, recipient, wethAddressOnL1, l1Gas, {
           value: fee / 2n,
         })
       ).to.be.reverted
@@ -246,11 +259,11 @@ describe('RelayBridge', function () {
       // Approve
       await weth.approve(bridgeAddress, amount)
 
-      const fee = await bridge.getFee(amount, recipient)
+      const fee = await bridge.getFee(amount, recipient, l1Gas)
       const wethAddressOnL1 = ethers.ZeroAddress
 
       await expect(
-        bridge.bridge(amount, recipient, wethAddressOnL1, {
+        bridge.bridge(amount, recipient, wethAddressOnL1, l1Gas, {
           value: fee / 2n,
         })
       )
@@ -268,11 +281,11 @@ describe('RelayBridge', function () {
       // Approve
       await weth.approve(bridgeAddress, amount)
 
-      const fee = await bridge.getFee(amount, recipient)
+      const fee = await bridge.getFee(amount, recipient, l1Gas)
       const wethAddressOnL1 = ethers.ZeroAddress
 
       await expect(
-        bridge.bridge(amount, recipient, wethAddressOnL1, {
+        bridge.bridge(amount, recipient, wethAddressOnL1, l1Gas, {
           value: fee,
         })
       ).to.be.revertedWithCustomError(bridge, 'BridgingFailed')
@@ -288,11 +301,11 @@ describe('RelayBridge', function () {
       // Approve
       await weth.approve(bridgeAddress, amount)
 
-      const fee = await bridge.getFee(amount, recipient)
+      const fee = await bridge.getFee(amount, recipient, l1Gas)
       const wethAddressOnL1 = ethers.ZeroAddress
       const value = fee * 10n
       const expectedBalanceAfter = balanceOfEthBefore - value
-      await bridge.bridge(amount, recipient, wethAddressOnL1, {
+      await bridge.bridge(amount, recipient, wethAddressOnL1, l1Gas, {
         value,
       })
 


### PR DESCRIPTION
It turns out that the gas for `handle` is depending too much on the base pool used and we can't really hard code it on the L2 without risking it to be too low for some transactions.
We're moving to a dynamic approach where the user has to submit a value. 