### PR TITLE
fix: prevent pendingBridgeFees underflow in processFailedHandler (DEC-652)

### DIFF
--- a/smart-contracts/contracts/RelayPool.sol
+++ b/smart-contracts/contracts/RelayPool.sol
@@ -650,6 +650,19 @@ contract RelayPool is ERC4626, Ownable {
     uint32 chainId,
     address bridge
   ) public returns (uint256 amount) {
+    return _claim(chainId, bridge, true);
+  }
+
+  /// @notice Internal claim logic with optional fee processing
+  /// @param chainId The origin chain ID
+  /// @param bridge The origin bridge address
+  /// @param chargeFee Whether to process bridge fees
+  /// @return amount The amount of assets claimed
+  function _claim(
+    uint32 chainId,
+    address bridge,
+    bool chargeFee
+  ) internal returns (uint256 amount) {
     OriginSettings storage origin = authorizedOrigins[chainId][bridge];
     if (origin.proxyBridge == address(0)) {
       revert UnauthorizedOrigin(chainId, bridge);
@@ -666,12 +679,15 @@ contract RelayPool is ERC4626, Ownable {
     // and we should deposit these funds into the yield pool
     depositAssetsInYieldPool(amount);
 
-    // The amount is the amount that was loaned + the fees
-    uint256 feeAmount = (amount * origin.bridgeFee) /
-      FRACTIONAL_BPS_DENOMINATOR;
-    pendingBridgeFees -= feeAmount;
-    // We need to account for it in a streaming fashion
-    addToStreamingAssets(feeAmount);
+    uint256 feeAmount = 0;
+    if (chargeFee) {
+      // The amount is the amount that was loaned + the fees
+      feeAmount = (amount * origin.bridgeFee) /
+        FRACTIONAL_BPS_DENOMINATOR;
+      pendingBridgeFees -= feeAmount;
+      // We need to account for it in a streaming fashion
+      addToStreamingAssets(feeAmount);
+    }
 
     emit BridgeCompleted(chainId, bridge, amount, feeAmount);
   }
@@ -792,7 +808,8 @@ contract RelayPool is ERC4626, Ownable {
     // Increase the outstanding debt with the amount
     increaseOutstandingDebt(message.amount, origin);
     // And immediately claim from the bridge to get the funds (and decrease the outstanding debt!)
-    uint256 amount = claim(chainId, bridge);
+    // Skip fee processing since this is a rescue operation (fees were never added to pendingBridgeFees)
+    uint256 amount = _claim(chainId, bridge, false);
     if (amount < message.amount) {
       revert InsufficientFunds(amount, message.amount);
     }

--- a/smart-contracts/test/RelayPool/failed-hyperlane.hardhat.ts
+++ b/smart-contracts/test/RelayPool/failed-hyperlane.hardhat.ts
@@ -196,3 +196,215 @@ describe('RelayPool: when a message was never received from Hyperlane', () => {
       .withArgs(amount / 2n, amount)
   })
 })
+
+describe('RelayPool: processFailedHandler with a non-zero bridge fee', () => {
+  const relayBridgeBase = '0x0000000000000000000000000000000000008453'
+  const bridgeFee = BigInt(1_000_000_000) // 1% in fractional bps
+  const FRACTIONAL_BPS_DENOMINATOR = BigInt(100_000_000_000)
+
+  let relayPool: RelayPool
+  let myToken: MyToken
+  let thirdPartyPool: MyYieldPool
+  let myWeth: MyWeth
+  let bridgeProxy: OPStackNativeBridgeProxy
+  let anotherBridgeProxy: OPStackNativeBridgeProxy
+
+  before(async () => {
+    const [user] = await ethers.getSigners()
+    const userAddress = await user.getAddress()
+    myToken = await ethers.deployContract('MyToken', ['My Token', 'TOKEN'])
+
+    myWeth = await ethers.deployContract('MyWeth')
+
+    thirdPartyPool = await ethers.deployContract('MyYieldPool', [
+      await myToken.getAddress(),
+      'My Yield Pool',
+      'YIELD',
+    ])
+
+    const parameters = {
+      RelayPool: {
+        asset: await myToken.getAddress(),
+        curator: userAddress,
+        hyperlaneMailbox: userAddress,
+        name: 'ERC20 RELAY POOL',
+        symbol: 'ERC20-REL',
+        thirdPartyPool: await thirdPartyPool.getAddress(),
+        weth: await myWeth.getAddress(),
+      },
+    }
+    ;({ relayPool } = await ignition.deploy(RelayPoolModule, {
+      parameters,
+    }))
+
+    const bridgeProxyParameters = {
+      OPStackNativeBridgeProxy: {
+        l1BridgeProxy: ethers.ZeroAddress,
+        portalProxy,
+        relayPool: await relayPool.getAddress(),
+        relayPoolChainId: 31337,
+      },
+    }
+    ;({ bridge: bridgeProxy } = await ignition.deploy(
+      OPStackNativeBridgeProxyModule,
+      { parameters: bridgeProxyParameters }
+    ))
+    ;({ bridge: anotherBridgeProxy } = await ignition.deploy(
+      OPStackNativeBridgeProxyModule,
+      { parameters: bridgeProxyParameters }
+    ))
+
+    await relayPool.addOrigin({
+      bridge: relayBridgeOptimism,
+      bridgeFee,
+      chainId: 10,
+      coolDown: 0,
+      curator: userAddress,
+      maxDebt: ethers.parseEther('10'),
+      proxyBridge: await bridgeProxy.getAddress(),
+    })
+
+    await relayPool.addOrigin({
+      bridge: relayBridgeBase,
+      bridgeFee,
+      chainId: 8453,
+      coolDown: 0,
+      curator: userAddress,
+      maxDebt: ethers.parseEther('10'),
+      proxyBridge: await anotherBridgeProxy.getAddress(),
+    })
+
+    const liquidity = ethers.parseUnits('100', 18)
+    await myToken.connect(user).mint(liquidity)
+    await myToken.connect(user).approve(await relayPool.getAddress(), liquidity)
+    await relayPool.connect(user).deposit(liquidity, userAddress)
+  })
+
+  it('should not underflow pendingBridgeFees when the message never went through handle', async () => {
+    const [user] = await ethers.getSigners()
+    const userAddress = await user.getAddress()
+    const amount = ethers.parseUnits('1')
+
+    // Sanity: pendingBridgeFees starts at 0, so any subtraction underflows.
+    expect(await relayPool.pendingBridgeFees()).to.equal(0)
+
+    // Simulate the slow bridge eventually delivering funds to the proxy,
+    // without any prior successful Hyperlane `handle` (so fees were never
+    // added to pendingBridgeFees).
+    await myToken.connect(user).transfer(await bridgeProxy.getAddress(), amount)
+
+    await relayPool.processFailedHandler(
+      10,
+      relayBridgeOptimism,
+      encodeData(100n, userAddress, amount)
+    )
+
+    // Without the fix the subtraction inside claim would revert here.
+    expect(await relayPool.pendingBridgeFees()).to.equal(0)
+  })
+
+  it('should emit BridgeCompleted with zero fees and not stream any fee assets', async () => {
+    const [user] = await ethers.getSigners()
+    const userAddress = await user.getAddress()
+    const amount = ethers.parseUnits('1')
+
+    await myToken.connect(user).transfer(await bridgeProxy.getAddress(), amount)
+
+    const totalAssetsToStreamBefore = await relayPool.totalAssetsToStream()
+
+    await expect(
+      relayPool.processFailedHandler(
+        10,
+        relayBridgeOptimism,
+        encodeData(101n, userAddress, amount)
+      )
+    )
+      .to.emit(relayPool, 'BridgeCompleted')
+      .withArgs(10, relayBridgeOptimism, amount, 0n)
+
+    // Streaming accounting must not include any fake fee amount.
+    const totalAssetsToStreamAfter = await relayPool.totalAssetsToStream()
+    expect(totalAssetsToStreamAfter).to.equal(totalAssetsToStreamBefore)
+  })
+
+  it('should send the full message amount to the recipient (no fee deduction on rescue path)', async () => {
+    const [user] = await ethers.getSigners()
+    const recipientAddress = ethers.Wallet.createRandom().address
+    const amount = ethers.parseUnits('1')
+
+    await myToken.connect(user).transfer(await bridgeProxy.getAddress(), amount)
+
+    const recipientBalanceBefore = await myToken.balanceOf(recipientAddress)
+
+    await relayPool.processFailedHandler(
+      10,
+      relayBridgeOptimism,
+      encodeData(102n, recipientAddress, amount)
+    )
+
+    const recipientBalanceAfter = await myToken.balanceOf(recipientAddress)
+    expect(recipientBalanceAfter - recipientBalanceBefore).to.equal(amount)
+  })
+
+  it('should not consume fees accrued from a successful handle on another message', async () => {
+    const [user] = await ethers.getSigners()
+    const recipientAddress = ethers.Wallet.createRandom().address
+    const amount = ethers.parseUnits('1')
+
+    // A normal Hyperlane message successfully goes through `handle` on one
+    // origin, which accumulates some pendingBridgeFees.
+    await relayPool.handle(
+      10,
+      ethers.zeroPadValue(relayBridgeOptimism, 32),
+      encodeData(200n, recipientAddress, amount)
+    )
+    const expectedFee = (amount * bridgeFee) / FRACTIONAL_BPS_DENOMINATOR
+    const pendingFeesAfterHandle = await relayPool.pendingBridgeFees()
+    expect(pendingFeesAfterHandle).to.be.greaterThanOrEqual(expectedFee)
+
+    // Now a separate message on a different origin fails to deliver via
+    // Hyperlane but the funds eventually arrive and are rescued through
+    // processFailedHandler. This must not touch the pendingBridgeFees that
+    // was accumulated for the first, unrelated message.
+    await myToken
+      .connect(user)
+      .transfer(await anotherBridgeProxy.getAddress(), amount)
+
+    await relayPool.processFailedHandler(
+      8453,
+      relayBridgeBase,
+      encodeData(201n, recipientAddress, amount)
+    )
+
+    expect(await relayPool.pendingBridgeFees()).to.equal(pendingFeesAfterHandle)
+  })
+
+  it('should still correctly decrement pendingBridgeFees on the normal claim path', async () => {
+    const [user] = await ethers.getSigners()
+    const recipientAddress = ethers.Wallet.createRandom().address
+    const amount = ethers.parseUnits('1')
+
+    const pendingFeesBefore = await relayPool.pendingBridgeFees()
+
+    // Go through the normal hyperlane path to accumulate a fee for this nonce
+    await relayPool.handle(
+      10,
+      ethers.zeroPadValue(relayBridgeOptimism, 32),
+      encodeData(300n, recipientAddress, amount)
+    )
+    const addedFee = (amount * bridgeFee) / FRACTIONAL_BPS_DENOMINATOR
+    expect(await relayPool.pendingBridgeFees()).to.equal(
+      pendingFeesBefore + addedFee
+    )
+
+    // Deliver the bridged funds and claim via the regular path
+    await myToken.connect(user).transfer(await bridgeProxy.getAddress(), amount)
+    await expect(relayPool.claim(10, relayBridgeOptimism))
+      .to.emit(relayPool, 'BridgeCompleted')
+      .withArgs(10, relayBridgeOptimism, amount, addedFee)
+
+    // The claim should have deducted exactly the fee that was added, returning
+    // pendingBridgeFees to where it was before this test started.
+    expect(await relayPool.pendingBridgeFees()).to.equal(pendingFeesBefore)
+  })
+})


### PR DESCRIPTION
## Summary
   - `processFailedHandler` (rescue path for failed Hyperlane messages)
   called `claim()` which unconditionally subtracts bridge fees from
   `pendingBridgeFees`
   - Since the rescue path never adds fees to `pendingBridgeFees`, this
   caused an arithmetic underflow (Solidity panic 0x11), making the rescue
   function permanently unusable
   - Extracted `_claim(chainId, bridge, chargeFee)` internal function that
   skips fee processing when `chargeFee` is false, used by
   `processFailedHandler`

   Fixes DEC-652

   ## Test plan
   - [x] Existing `processFailedHandler` tests pass
   - [x] All other RelayPool tests unaffected
   - [ ] Verify on testnet that rescue path works with non-zero bridge fees