### PR TITLE
Restrict Claude code review to PRs targeting main

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,6 +3,7 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
+    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Adds `branches: [main]` to the `pull_request` trigger in `.github/workflows/claude-code-review.yml` so the Claude code review only runs on PRs whose base branch is `main`.

Matches the same change opened on `solver`, `relay-client`, `team-faucet`, and `settlement-protocol`.

## Test plan
- [ ] Open a PR targeting `main` — Claude review runs
- [ ] Open a PR targeting any other base branch — Claude review is skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)