### PR TITLE
fix(backend): derive nativeBridgeStatus monotonically from hash columns

### DIFF
--- a/backend/src/handlers/OPPortal/WithdrawalFinalized.ts
+++ b/backend/src/handlers/OPPortal/WithdrawalFinalized.ts
@@ -1,6 +1,7 @@
-import { eq, and } from 'ponder'
+import { eq } from 'ponder'
 import { Context, Event } from 'ponder:registry'
 import { bridgeTransaction } from 'ponder:schema'
+import { computeNativeBridgeStatus } from '../../utils/nativeBridgeStatus.js'
 
 export default async function ({
   event,
@@ -9,12 +10,34 @@ export default async function ({
   event: Event<'OPPortal:WithdrawalFinalized'>
   context: Context<'OPPortal:WithdrawalFinalized'>
 }) {
+  const finalizationTimestamp = event.block.timestamp
+  const nativeBridgeFinalizedTxHash = event.transaction.hash
+
+  // Finalize is terminal so the helper always returns FINALIZED here, but routing every
+  // handler through computeNativeBridgeStatus keeps the write rule uniform across the codebase.
+  const [existing] = await context.db.sql
+    .select()
+    .from(bridgeTransaction)
+    .where(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))
+    .limit(1)
+
+  if (!existing) {
+    return
+  }
+
+  const nativeBridgeStatus = computeNativeBridgeStatus({
+    finalizationTimestamp,
+    loanEmittedTxHash: existing.loanEmittedTxHash,
+    nativeBridgeFinalizedTxHash,
+    opProofTxHash: existing.opProofTxHash,
+  })
+
   await context.db.sql
     .update(bridgeTransaction)
     .set({
-      finalizationTimestamp: event.block.timestamp,
-      nativeBridgeFinalizedTxHash: event.transaction.hash,
-      nativeBridgeStatus: 'FINALIZED',
+      finalizationTimestamp,
+      nativeBridgeFinalizedTxHash,
+      nativeBridgeStatus,
       updatedAt: new Date(),
     })
     .where(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))

--- a/backend/src/handlers/OPPortal/WithdrawalFinalized.ts
+++ b/backend/src/handlers/OPPortal/WithdrawalFinalized.ts
@@ -13,23 +13,12 @@ export default async function ({
   const finalizationTimestamp = event.block.timestamp
   const nativeBridgeFinalizedTxHash = event.transaction.hash
 
-  // Finalize is terminal so the helper always returns FINALIZED here, but routing every
-  // handler through computeNativeBridgeStatus keeps the write rule uniform across the codebase.
-  const [existing] = await context.db.sql
-    .select()
-    .from(bridgeTransaction)
-    .where(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))
-    .limit(1)
-
-  if (!existing) {
-    return
-  }
-
+  // FINALIZED is terminal: the helper resolves it from the finalization evidence alone,
+  // so we can skip a SELECT of the existing row. Going through the helper keeps the
+  // mapping from evidence to status in one place.
   const nativeBridgeStatus = computeNativeBridgeStatus({
     finalizationTimestamp,
-    loanEmittedTxHash: existing.loanEmittedTxHash,
     nativeBridgeFinalizedTxHash,
-    opProofTxHash: existing.opProofTxHash,
   })
 
   await context.db.sql

--- a/backend/src/handlers/OPPortal/WithdrawalProven.ts
+++ b/backend/src/handlers/OPPortal/WithdrawalProven.ts
@@ -1,9 +1,10 @@
 import networks from '@relay-vaults/networks'
 import { OriginNetworkConfig } from '@relay-vaults/types'
 import { SEVEN_DAYS } from '../../constants'
-import { eq, and } from 'ponder'
+import { eq } from 'ponder'
 import { Context, Event } from 'ponder:registry'
 import { bridgeTransaction } from 'ponder:schema'
+import { computeNativeBridgeStatus } from '../../utils/nativeBridgeStatus.js'
 
 export default async function ({
   event,
@@ -14,16 +15,34 @@ export default async function ({
 }) {
   const networkConfig = networks[context.chain.id] as OriginNetworkConfig
   const delay = BigInt(networkConfig.withdrawalDelay || SEVEN_DAYS)
+  const opProofTxHash = event.transaction.hash
+
+  // Read the existing row so the recomputed status reflects the union of every hash field,
+  // not just the proof we are about to write. Prevents a later LoanEmitted from clobbering this back to HANDLED.
+  const [existing] = await context.db.sql
+    .select()
+    .from(bridgeTransaction)
+    .where(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))
+    .limit(1)
+
+  if (!existing) {
+    return
+  }
+
+  const nativeBridgeStatus = computeNativeBridgeStatus({
+    finalizationTimestamp: existing.finalizationTimestamp,
+    loanEmittedTxHash: existing.loanEmittedTxHash,
+    nativeBridgeFinalizedTxHash: existing.nativeBridgeFinalizedTxHash,
+    opProofTxHash,
+  })
 
   await context.db.sql
     .update(bridgeTransaction)
     .set({
       expectedFinalizationTimestamp: event.block.timestamp + delay,
-      nativeBridgeStatus: 'PROVEN',
-      opProofTxHash: event.transaction.hash,
+      nativeBridgeStatus,
+      opProofTxHash,
       updatedAt: new Date(),
     })
-    .where(
-      and(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))
-    )
+    .where(eq(bridgeTransaction.opWithdrawalHash, event.args.withdrawalHash))
 }

--- a/backend/src/handlers/OrbitOutbox/OutBoxTransactionExecuted.ts
+++ b/backend/src/handlers/OrbitOutbox/OutBoxTransactionExecuted.ts
@@ -13,23 +13,11 @@ export default async function ({
   const finalizationTimestamp = event.block.timestamp
   const nativeBridgeFinalizedTxHash = event.transaction.hash
 
-  const [existing] = await context.db.sql
-    .select()
-    .from(bridgeTransaction)
-    .where(
-      eq(bridgeTransaction.arbTransactionIndex, event.args.transactionIndex)
-    )
-    .limit(1)
-
-  if (!existing) {
-    return
-  }
-
+  // FINALIZED is terminal: the helper resolves it from the finalization evidence alone,
+  // so the SELECT of the existing row is unnecessary here.
   const nativeBridgeStatus = computeNativeBridgeStatus({
     finalizationTimestamp,
-    loanEmittedTxHash: existing.loanEmittedTxHash,
     nativeBridgeFinalizedTxHash,
-    opProofTxHash: existing.opProofTxHash,
   })
 
   await context.db.sql

--- a/backend/src/handlers/OrbitOutbox/OutBoxTransactionExecuted.ts
+++ b/backend/src/handlers/OrbitOutbox/OutBoxTransactionExecuted.ts
@@ -1,6 +1,7 @@
 import { eq } from 'ponder'
 import { Context, Event } from 'ponder:registry'
 import { bridgeTransaction } from 'ponder:schema'
+import { computeNativeBridgeStatus } from '../../utils/nativeBridgeStatus.js'
 
 export default async function ({
   event,
@@ -9,12 +10,34 @@ export default async function ({
   event: Event<'OrbitOutbox:OutBoxTransactionExecuted'>
   context: Context<'OrbitOutbox:OutBoxTransactionExecuted'>
 }) {
+  const finalizationTimestamp = event.block.timestamp
+  const nativeBridgeFinalizedTxHash = event.transaction.hash
+
+  const [existing] = await context.db.sql
+    .select()
+    .from(bridgeTransaction)
+    .where(
+      eq(bridgeTransaction.arbTransactionIndex, event.args.transactionIndex)
+    )
+    .limit(1)
+
+  if (!existing) {
+    return
+  }
+
+  const nativeBridgeStatus = computeNativeBridgeStatus({
+    finalizationTimestamp,
+    loanEmittedTxHash: existing.loanEmittedTxHash,
+    nativeBridgeFinalizedTxHash,
+    opProofTxHash: existing.opProofTxHash,
+  })
+
   await context.db.sql
     .update(bridgeTransaction)
     .set({
-      finalizationTimestamp: event.block.timestamp,
-      nativeBridgeFinalizedTxHash: event.transaction.hash,
-      nativeBridgeStatus: 'FINALIZED',
+      finalizationTimestamp,
+      nativeBridgeFinalizedTxHash,
+      nativeBridgeStatus,
       updatedAt: new Date(),
     })
     .where(

--- a/backend/src/handlers/RelayPool/LoanEmitted.ts
+++ b/backend/src/handlers/RelayPool/LoanEmitted.ts
@@ -14,6 +14,7 @@ import { bridgeTransaction, relayPool, poolOrigin } from 'ponder:schema'
 import { BPS_DIVISOR } from '../../constants.js'
 import { logger } from '../../logger.js'
 import { chainIdFromDomainId } from '@relay-vaults/helpers'
+import { computeNativeBridgeStatus } from '../../utils/nativeBridgeStatus.js'
 
 export default async function ({
   event,
@@ -26,22 +27,37 @@ export default async function ({
   const { bridge, chainId: domainId } = origin
 
   const originChainId = chainIdFromDomainId(domainId)
-  // Update the corresponding bridgeTransaction record with loanEmittedTxHash
-  // We use upsert (insert with onConflictDoUpdate) here because the record may not exist yet if the L2 indexing is slower.
+  const loanEmittedTxHash = event.transaction.hash
+
+  // The record may not exist yet if L2 indexing is slower than L1, hence the upsert.
+  // Status is derived from the union of existing on-chain evidence and the new loan hash,
+  // so a late-arriving Hyperlane handle can never regress a row that was already PROVEN/FINALIZED.
+  const existing = await context.db.find(bridgeTransaction, {
+    nonce,
+    originBridgeAddress: bridge,
+    originChainId,
+  })
+  const nativeBridgeStatus = computeNativeBridgeStatus({
+    finalizationTimestamp: existing?.finalizationTimestamp,
+    loanEmittedTxHash,
+    nativeBridgeFinalizedTxHash: existing?.nativeBridgeFinalizedTxHash,
+    opProofTxHash: existing?.opProofTxHash,
+  })
+
   await context.db
     .insert(bridgeTransaction)
     .values({
       createdAt: new Date(),
-      loanEmittedTxHash: event.transaction.hash,
-      nativeBridgeStatus: 'HANDLED',
+      loanEmittedTxHash,
+      nativeBridgeStatus,
       nonce,
       originBridgeAddress: bridge,
       originChainId,
       updatedAt: new Date(),
     })
     .onConflictDoUpdate({
-      loanEmittedTxHash: event.transaction.hash,
-      nativeBridgeStatus: 'HANDLED',
+      loanEmittedTxHash,
+      nativeBridgeStatus,
       updatedAt: new Date(),
     })
 

--- a/backend/src/handlers/Zksync/BridgeMint.ts
+++ b/backend/src/handlers/Zksync/BridgeMint.ts
@@ -1,9 +1,10 @@
 import networks from '@relay-vaults/networks'
-import { eq, and } from 'ponder'
+import { eq } from 'ponder'
 import { ABIs } from '@relay-vaults/helpers'
 import { Context, Event } from 'ponder:registry'
 import { bridgeTransaction } from 'ponder:schema'
 import { decodeFunctionData, Hex, keccak256 } from 'viem'
+import { computeNativeBridgeStatus } from '../../utils/nativeBridgeStatus.js'
 
 /**
  * Extract the L2-to-L1 message from the finalization tx input.
@@ -50,15 +51,35 @@ export default async function ({
       const message = extractMessage(event.transaction.input)
       if (message) {
         const expectedKey = keccak256(message)
+        const finalizationTimestamp = event.block.timestamp
+        const nativeBridgeFinalizedTxHash = event.transaction.hash
+
+        const [existing] = await context.db.sql
+          .select()
+          .from(bridgeTransaction)
+          .where(eq(bridgeTransaction.zksyncWithdrawalHash, expectedKey))
+          .limit(1)
+
+        if (!existing) {
+          return
+        }
+
+        const nativeBridgeStatus = computeNativeBridgeStatus({
+          finalizationTimestamp,
+          loanEmittedTxHash: existing.loanEmittedTxHash,
+          nativeBridgeFinalizedTxHash,
+          opProofTxHash: existing.opProofTxHash,
+        })
+
         await context.db.sql
           .update(bridgeTransaction)
           .set({
-            finalizationTimestamp: event.block.timestamp,
-            nativeBridgeFinalizedTxHash: event.transaction.hash,
-            nativeBridgeStatus: 'FINALIZED',
+            finalizationTimestamp,
+            nativeBridgeFinalizedTxHash,
+            nativeBridgeStatus,
             updatedAt: new Date(),
           })
-          .where(and(eq(bridgeTransaction.zksyncWithdrawalHash, expectedKey)))
+          .where(eq(bridgeTransaction.zksyncWithdrawalHash, expectedKey))
       }
     }
   }

--- a/backend/src/handlers/Zksync/BridgeMint.ts
+++ b/backend/src/handlers/Zksync/BridgeMint.ts
@@ -54,21 +54,10 @@ export default async function ({
         const finalizationTimestamp = event.block.timestamp
         const nativeBridgeFinalizedTxHash = event.transaction.hash
 
-        const [existing] = await context.db.sql
-          .select()
-          .from(bridgeTransaction)
-          .where(eq(bridgeTransaction.zksyncWithdrawalHash, expectedKey))
-          .limit(1)
-
-        if (!existing) {
-          return
-        }
-
+        // FINALIZED is terminal: the helper resolves it from the finalization evidence alone.
         const nativeBridgeStatus = computeNativeBridgeStatus({
           finalizationTimestamp,
-          loanEmittedTxHash: existing.loanEmittedTxHash,
           nativeBridgeFinalizedTxHash,
-          opProofTxHash: existing.opProofTxHash,
         })
 
         await context.db.sql

--- a/backend/src/utils/nativeBridgeStatus.ts
+++ b/backend/src/utils/nativeBridgeStatus.ts
@@ -1,0 +1,33 @@
+// ABOUTME: Pure helper that derives nativeBridgeStatus from a bridge_transaction's hash columns.
+// ABOUTME: Single source of truth used by every handler that writes to the row, so the stored value never regresses.
+
+export type NativeBridgeStatus =
+  | 'INITIATED'
+  | 'HANDLED'
+  | 'PROVEN'
+  | 'FINALIZED'
+
+export interface NativeBridgeStatusInputs {
+  nativeBridgeFinalizedTxHash?: `0x${string}` | null
+  finalizationTimestamp?: bigint | null
+  opProofTxHash?: `0x${string}` | null
+  loanEmittedTxHash?: `0x${string}` | null
+}
+
+// The protocol's state machine progresses INITIATED -> HANDLED -> PROVEN -> FINALIZED.
+// The presence of a hash field is the durable on-chain evidence that the matching transition fired,
+// so we always pick the highest reached state regardless of write ordering in the indexer.
+export const computeNativeBridgeStatus = (
+  inputs: NativeBridgeStatusInputs
+): NativeBridgeStatus => {
+  if (inputs.nativeBridgeFinalizedTxHash || inputs.finalizationTimestamp) {
+    return 'FINALIZED'
+  }
+  if (inputs.opProofTxHash) {
+    return 'PROVEN'
+  }
+  if (inputs.loanEmittedTxHash) {
+    return 'HANDLED'
+  }
+  return 'INITIATED'
+}

--- a/backend/src/utils/nativeBridgeStatus.ts
+++ b/backend/src/utils/nativeBridgeStatus.ts
@@ -17,16 +17,21 @@ export interface NativeBridgeStatusInputs {
 // The protocol's state machine progresses INITIATED -> HANDLED -> PROVEN -> FINALIZED.
 // The presence of a hash field is the durable on-chain evidence that the matching transition fired,
 // so we always pick the highest reached state regardless of write ordering in the indexer.
+// The checks use `!= null` rather than truthiness so a hypothetical `0n` timestamp or zero-hash
+// is still treated as evidence that the transition fired.
 export const computeNativeBridgeStatus = (
   inputs: NativeBridgeStatusInputs
 ): NativeBridgeStatus => {
-  if (inputs.nativeBridgeFinalizedTxHash || inputs.finalizationTimestamp) {
+  if (
+    inputs.nativeBridgeFinalizedTxHash != null ||
+    inputs.finalizationTimestamp != null
+  ) {
     return 'FINALIZED'
   }
-  if (inputs.opProofTxHash) {
+  if (inputs.opProofTxHash != null) {
     return 'PROVEN'
   }
-  if (inputs.loanEmittedTxHash) {
+  if (inputs.loanEmittedTxHash != null) {
     return 'HANDLED'
   }
   return 'INITIATED'

--- a/backend/tests/nativeBridgeStatus.test.ts
+++ b/backend/tests/nativeBridgeStatus.test.ts
@@ -35,6 +35,14 @@ describe('computeNativeBridgeStatus', () => {
     )
   })
 
+  // Guards against truthiness-based checks: a hypothetical 0n timestamp must
+  // still count as evidence that finalization fired.
+  it('returns FINALIZED for a 0n finalizationTimestamp', () => {
+    expect(computeNativeBridgeStatus({ finalizationTimestamp: 0n })).toBe(
+      'FINALIZED'
+    )
+  })
+
   it('PROVEN beats HANDLED — both hashes set', () => {
     expect(
       computeNativeBridgeStatus({

--- a/backend/tests/nativeBridgeStatus.test.ts
+++ b/backend/tests/nativeBridgeStatus.test.ts
@@ -1,0 +1,85 @@
+// ABOUTME: Covers the monotonic-by-evidence rule for nativeBridgeStatus, including the LoanEmitted-after-WithdrawalProven regression.
+// ABOUTME: The protocol observed this regression in production after the Aave outage of 2026-04, when delayed Hyperlane retries clobbered already-PROVEN rows.
+
+import { describe, expect, it } from 'vitest'
+import { computeNativeBridgeStatus } from '../src/utils/nativeBridgeStatus.js'
+
+const LOAN = '0xaa' as const
+const PROOF = '0xbb' as const
+const FINALIZE = '0xcc' as const
+
+describe('computeNativeBridgeStatus', () => {
+  it('returns INITIATED when no hash is set', () => {
+    expect(computeNativeBridgeStatus({})).toBe('INITIATED')
+  })
+
+  it('returns HANDLED when only loanEmittedTxHash is set', () => {
+    expect(computeNativeBridgeStatus({ loanEmittedTxHash: LOAN })).toBe(
+      'HANDLED'
+    )
+  })
+
+  it('returns PROVEN when only opProofTxHash is set', () => {
+    expect(computeNativeBridgeStatus({ opProofTxHash: PROOF })).toBe('PROVEN')
+  })
+
+  it('returns FINALIZED when nativeBridgeFinalizedTxHash is set', () => {
+    expect(
+      computeNativeBridgeStatus({ nativeBridgeFinalizedTxHash: FINALIZE })
+    ).toBe('FINALIZED')
+  })
+
+  it('returns FINALIZED when only finalizationTimestamp is set (zksync path)', () => {
+    expect(computeNativeBridgeStatus({ finalizationTimestamp: 1n })).toBe(
+      'FINALIZED'
+    )
+  })
+
+  it('PROVEN beats HANDLED — both hashes set', () => {
+    expect(
+      computeNativeBridgeStatus({
+        loanEmittedTxHash: LOAN,
+        opProofTxHash: PROOF,
+      })
+    ).toBe('PROVEN')
+  })
+
+  it('FINALIZED beats every earlier state', () => {
+    expect(
+      computeNativeBridgeStatus({
+        loanEmittedTxHash: LOAN,
+        nativeBridgeFinalizedTxHash: FINALIZE,
+        opProofTxHash: PROOF,
+      })
+    ).toBe('FINALIZED')
+  })
+
+  // The Aave-outage regression: a row was PROVEN, then days later Hyperlane
+  // finally delivered and LoanEmitted fired. Recomputing from the merged hash
+  // set must keep the row at PROVEN, not regress to HANDLED.
+  it('does not regress PROVEN to HANDLED when a late LoanEmitted arrives', () => {
+    const existing = { opProofTxHash: PROOF }
+    const merged = { ...existing, loanEmittedTxHash: LOAN }
+    expect(computeNativeBridgeStatus(merged)).toBe('PROVEN')
+  })
+
+  it('does not regress FINALIZED to HANDLED when a late LoanEmitted arrives', () => {
+    const existing = {
+      nativeBridgeFinalizedTxHash: FINALIZE,
+      opProofTxHash: PROOF,
+    }
+    const merged = { ...existing, loanEmittedTxHash: LOAN }
+    expect(computeNativeBridgeStatus(merged)).toBe('FINALIZED')
+  })
+
+  it('treats explicit nulls the same as missing fields', () => {
+    expect(
+      computeNativeBridgeStatus({
+        finalizationTimestamp: null,
+        loanEmittedTxHash: null,
+        nativeBridgeFinalizedTxHash: null,
+        opProofTxHash: null,
+      })
+    ).toBe('INITIATED')
+  })
+})


### PR DESCRIPTION
## Summary

`bridge_transaction.nativeBridgeStatus` could regress (e.g. PROVEN → HANDLED) because every handler hard-coded the status string without considering the row's existing on-chain evidence.

The Aave outage of 2026-04 surfaced this in production:

1. Bridges initiated, `LoanEmitted` reverted on the destination because `RelayPool.handle()` couldn't deposit into the broken Aave pool. Hyperlane retried for ~10 days.
2. Meanwhile the OP claimer ran on schedule and submitted proofs → `WithdrawalProven` → status set to `PROVEN`. ✓
3. Aave was restored. The next Hyperlane retry succeeded, fired `LoanEmitted`, and the handler **clobbered status back to `HANDLED`** on rows that were already proven (and in some cases finalized).

The proof tx hashes were preserved on those rows — only the status field went backwards. UI showed wrong info.

## What changed

Every handler that touches `nativeBridgeStatus` now routes the value through `computeNativeBridgeStatus()`, which derives it from the union of hash columns:

```
FINALIZED if nativeBridgeFinalizedTxHash || finalizationTimestamp
PROVEN    if opProofTxHash
HANDLED   if loanEmittedTxHash
INITIATED otherwise
```

This makes the column monotonic by construction and self-correcting — no out-of-order event sequence can regress a row's status, because the value is reconstructed from durable on-chain evidence on every write.

Affected handlers:
- `RelayPool/LoanEmitted.ts` — was the proximate cause of the regression
- `OPPortal/WithdrawalProven.ts`
- `OPPortal/WithdrawalFinalized.ts`
- `OrbitOutbox/OutBoxTransactionExecuted.ts`
- `Zksync/BridgeMint.ts`

`RelayBridge/BridgeInitiated.ts` already only set status on insert (not on conflict), so it was already non-regressing — left untouched to keep the diff minimal.

## No backfill needed

The indexer runs with `--schema $IMAGE_TAG`. The next deploy spins up a fresh schema and replays every event through the new handlers, so existing-but-wrong rows are fixed by the redeploy itself.

## Test plan

- [x] New unit tests in `backend/tests/nativeBridgeStatus.test.ts` cover the helper, including the LoanEmitted-after-WithdrawalProven regression case (10 tests, all pass).
- [ ] After merge & redeploy, spot-check a handful of the rows that currently show `HANDLED` despite having `opProofTxHash` set, and confirm they flip to `PROVEN` (or `FINALIZED` if `nativeBridgeFinalizedTxHash` is also set).
- [ ] Confirm the claimer's `where: { nativeBridgeStatus: 'HANDLED' }` query continues to find genuine work post-redeploy (i.e. that we're not over-correcting and starving the claimer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)